### PR TITLE
Update binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -77,7 +77,12 @@
       "cflags": [
         "-Wall",
         "-O3"
-      ]
+      ],
+      "xcode_settings": {
+        "OTHER_CFLAGS": [
+          "-Wno-unused-function"
+        ],
+      }
     },
     {
       "target_name": "action_after_build",


### PR DESCRIPTION
This should eliminate these warning on Mac:
```
  CC(target) Release/obj.target/zopfli/zopfli/src/zopfli/lz77.o
In file included from ../zopfli/src/zopfli/lz77.c:21:
../zopfli/src/zopfli/symbols.h:38:12: warning: unused function 'ZopfliGetDistExtraBits' [-Wunused-function]
static int ZopfliGetDistExtraBits(int dist) {
           ^
../zopfli/src/zopfli/symbols.h:61:12: warning: unused function 'ZopfliGetDistExtraBitsValue' [-Wunused-function]
static int ZopfliGetDistExtraBitsValue(int dist) {
           ^
../zopfli/src/zopfli/symbols.h:138:12: warning: unused function 'ZopfliGetLengthExtraBits' [-Wunused-function]
static int ZopfliGetLengthExtraBits(int l) {
           ^
../zopfli/src/zopfli/symbols.h:161:12: warning: unused function 'ZopfliGetLengthExtraBitsValue' [-Wunused-function]
static int ZopfliGetLengthExtraBitsValue(int l) {
           ^
../zopfli/src/zopfli/symbols.h:222:12: warning: unused function 'ZopfliGetLengthSymbolExtraBits' [-Wunused-function]
static int ZopfliGetLengthSymbolExtraBits(int s) {
           ^
../zopfli/src/zopfli/symbols.h:231:12: warning: unused function 'ZopfliGetDistSymbolExtraBits' [-Wunused-function]
static int ZopfliGetDistSymbolExtraBits(int s) {
           ^
6 warnings generated.
  CC(target) Release/obj.target/zopfli/zopfli/src/zopfli/squeeze.o
In file included from ../zopfli/src/zopfli/squeeze.c:28:
../zopfli/src/zopfli/symbols.h:61:12: warning: unused function 'ZopfliGetDistExtraBitsValue' [-Wunused-function]
static int ZopfliGetDistExtraBitsValue(int dist) {
           ^
../zopfli/src/zopfli/symbols.h:161:12: warning: unused function 'ZopfliGetLengthExtraBitsValue' [-Wunused-function]
static int ZopfliGetLengthExtraBitsValue(int l) {
           ^
../zopfli/src/zopfli/symbols.h:222:12: warning: unused function 'ZopfliGetLengthSymbolExtraBits' [-Wunused-function]
static int ZopfliGetLengthSymbolExtraBits(int s) {
           ^
../zopfli/src/zopfli/symbols.h:231:12: warning: unused function 'ZopfliGetDistSymbolExtraBits' [-Wunused-function]
static int ZopfliGetDistSymbolExtraBits(int s) {
           ^
4 warnings generated.
```